### PR TITLE
The confstruct depedency is specified in the gemspec

### DIFF
--- a/settings.gemspec
+++ b/settings.gemspec
@@ -8,4 +8,6 @@ Gem::Specification.new do |s|
   s.files = Dir.glob('{lib}/**/*')
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 1.9.2'
+
+  s.add_runtime_dependency 'confstruct', '0.2.7'
 end


### PR DESCRIPTION
Although we can't manage our `prox_gem` dependencies in a sane way,
there is no reason to not use bundler to add this gem's depedencies
