### PR TITLE
A subclass can provide the settings file pathname

### DIFF
--- a/lib/settings/settings.rb
+++ b/lib/settings/settings.rb
@@ -22,7 +22,7 @@ class Settings
     else
       logger.trace "Building based on a pathname"
       pathname = data_source
-      pathname ||= File::Defaults.filename
+      pathname ||= get_pathname
       pathname = File.canonical(pathname)
       File.validate(pathname)
       raw_data = read_file(pathname)
@@ -37,6 +37,25 @@ class Settings
     logger.debug "Built"
 
     instance
+  end
+
+  def self.get_pathname
+    pathname ||= implementer_pathname
+    pathname ||= File::Defaults.filename
+    pathname
+  end
+
+  def self.implementer_pathname
+    logger.trace "Getting pathname from the implementer"
+
+    unless self.respond_to? :pathname
+      logger.trace "Implementer doesn't provide a pathname"
+      return nil
+    end
+
+    self.pathname.tap do |pathname|
+      logger.trace "Got pathname from the implementer (#{pathname})"
+    end
   end
 
   def self.confstruct(raw_data)

--- a/test/spec/settings/implementer_settings.json
+++ b/test/spec/settings/implementer_settings.json
@@ -1,0 +1,3 @@
+{
+  "some_setting": "some value"
+}

--- a/test/spec/settings/implementer_settings_file.rb
+++ b/test/spec/settings/implementer_settings_file.rb
@@ -1,0 +1,20 @@
+module ImplementerPathname
+  def self.settings
+    Example.build
+  end
+
+  class Example < Settings
+    def self.pathname
+      ::File.expand_path('../implementer_settings.json', __FILE__)
+    end
+  end
+end
+
+describe "Implementer Pathname" do
+  specify "A subclass can specify the pathname by implementing a class method named 'pathname'" do
+    settings = ImplementerPathname.settings
+    pathname = ImplementerPathname::Example.pathname
+
+    assert(settings.pathname == pathname)
+  end
+end


### PR DESCRIPTION
A subclass can specify the pathname by implementing a class method named 'pathname'. Specialized settings classes, eg: Warehouse::Settings just have to define `self.pathname`.

For example:

``` ruby
module Warehouse
  class Settings < ::Settings
    def self.instance
      @instance ||= build
    end

    def self.pathname
      ::File.expand_path('../../../settings/warehouse.json', __FILE__)
    end
  end
end
```
