### PR TITLE
Ancestor attributes are assignable

### DIFF
--- a/lib/settings/setting/assignment.rb
+++ b/lib/settings/setting/assignment.rb
@@ -30,7 +30,7 @@ class Settings
       end
 
       def assignable?(receiver, attribute)
-        receiver.respond_to? setter_name(attribute)
+        receiver.respond_to?(setter_name(attribute), true)
       end
 
       def setter_name(attribute)

--- a/test/spec/settings/ancestor-attributes.rb
+++ b/test/spec/settings/ancestor-attributes.rb
@@ -1,0 +1,24 @@
+module AncestorAttributes
+  def self.example
+    Example.new
+  end
+
+  def self.assignment
+    Settings::Setting::Assignment
+  end
+
+  class Super
+    setting :some_setting
+  end
+
+  class Example < Super
+  end
+end
+
+describe "Ancestor Attributes" do
+  specify "An ancestor's attribute is assignable" do
+    example = AncestorAttributes.example
+
+    assert(AncestorAttributes.assignment.assignable?(example, :some_setting))
+  end
+end

--- a/test/spec/settings/assignment.rb
+++ b/test/spec/settings/assignment.rb
@@ -13,7 +13,7 @@ module Assignment
   end
 end
 
-describe Settings::Setting::Assignment do
+describe "Assignment" do
   specify "Determine whether the attribute is a setting" do
     example = Assignment.example
 


### PR DESCRIPTION
A setting declared in a super class is also considered a setting of its subclass.
